### PR TITLE
Support locale directories in the root of sources.

### DIFF
--- a/lib/multilang.js
+++ b/lib/multilang.js
@@ -6,7 +6,7 @@ function Multilang(ops) {
     this.default = ops.default;
     this.locales = ops.locales;
     this.pattern = RegExp('.*_('+ ops.locales.join('|') +')(?:\..*)?$');
-    this.pathPattern = RegExp('/(' + ops.locales.join('|') +')/');
+    this.pathPattern = RegExp('(^(' + ops.locales.join('|') +')/|/(' + ops.locales.join('|') +')/)');
 }
 
 Multilang.prototype.getAltFilename = function (file, fromLocale, toLocale) {
@@ -14,7 +14,8 @@ Multilang.prototype.getAltFilename = function (file, fromLocale, toLocale) {
 
     // Locale in the path.
     if (this.pathPattern.test(file)) {
-      return file.replace('/' + fromLocale + '/', '/' + toLocale + '/');
+      var replacementString = file.match(this.pathPattern)[0].replace(fromLocale, toLocale);
+      return file.replace(this.pathPattern, replacementString);
     }
 
     // Locale in the filename.
@@ -31,7 +32,11 @@ Multilang.prototype.getBaseFilename = function (file) {
 
     // Locale in the path.
     if (this.pathPattern.test(file)) {
-      return file.replace(RegExp('/('+ this.locales.join('|') +')/'), '/' + this.default + '/');
+      var replacementString = file.match(this.pathPattern)[0].replace(
+        RegExp('(/?)('+ this.locales.join('|') +')(/)'),
+        '$1' + this.default + '$3'
+      );
+      return file.replace(this.pathPattern, replacementString);
     }
 
     // Locale in the filename.
@@ -42,7 +47,10 @@ Multilang.prototype.getBaseFilename = function (file) {
 Multilang.prototype.getLocale = function (file) {
     // Locale in the path.
     if (this.pathPattern.test(file)) {
-        return file.match(this.pathPattern)[1];
+        return file.match(this.pathPattern)[0].replace(
+          RegExp('(/?)('+ this.locales.join('|') +')(/)'),
+          '$2'
+        );
     }
 
     // Locale in the filename.
@@ -65,7 +73,7 @@ Multilang.prototype.getPlugin = function () {
         ms.metadata().defaultLocale = self.default;
 
         for (var file in files) {
-            if (self.pattern.test(file)) {
+            if (self.pattern.test(file) || self.pathPattern.test(file)) {
                 var base = self.getBaseFilename(file);
 
                 files[file].locale = self.getLocale(file);

--- a/test/multilang.js
+++ b/test/multilang.js
@@ -16,6 +16,8 @@ describe('/lib/multilang.js', function () {
             expect(multilang.getAltFilename('some/path/file_es.md', 'es', 'es')).to.equal('some/path/file_es.md');
             expect(multilang.getAltFilename('some/es/file.md', 'es', 'ca')).to.equal('some/ca/file.md');
             expect(multilang.getAltFilename('some/es/file.md', 'es', 'es')).to.equal('some/es/file.md');
+            expect(multilang.getAltFilename('es/file.md', 'es', 'ca')).to.equal('ca/file.md');
+            expect(multilang.getAltFilename('es/file.md', 'es', 'es')).to.equal('es/file.md');
         });
     });
 
@@ -27,10 +29,13 @@ describe('/lib/multilang.js', function () {
             expect(multilang.getBaseFilename('some/path/file_en.md')).to.equal('some/path/file_es.md');
             expect(multilang.getBaseFilename('some/es/file.md')).to.equal('some/es/file.md');
             expect(multilang.getBaseFilename('some/en/file.md')).to.equal('some/es/file.md');
+            expect(multilang.getBaseFilename('es/file.md')).to.equal('es/file.md');
+            expect(multilang.getBaseFilename('en/file.md')).to.equal('es/file.md');
         });
 
         it('should ignore unknown locales', function () {
             expect(multilang.getBaseFilename('index_ca.html')).to.equal('index_ca.html');
+            expect(multilang.getBaseFilename('ca/file.md')).to.equal('ca/file.md');
         });
     });
 
@@ -42,6 +47,8 @@ describe('/lib/multilang.js', function () {
             expect(multilang.getLocale('some/path/file_en.md')).to.equal('en');
             expect(multilang.getLocale('some/es/file.md')).to.equal('es');
             expect(multilang.getLocale('some/en/file.md')).to.equal('en');
+            expect(multilang.getLocale('es/file.md')).to.equal('es');
+            expect(multilang.getLocale('en/file.md')).to.equal('en');
         });
     });
 


### PR DESCRIPTION
Previously we only supported locales that were more than one level deep
in a directory. We now support locale directories at the root.
