### PR TITLE
Add platform specific separator

### DIFF
--- a/lib/multilang.js
+++ b/lib/multilang.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var extname = require('path').extname;
+var path = require('path');
+var extname = path.extname;
+var sep = path.sep;
 
 function Multilang(ops) {
     this.default = ops.default;
@@ -115,7 +117,7 @@ Multilang.prototype.getPlugin = function () {
                     files['index'+ ext] = files[file];
                 } else {
                     files[file].path = files[file].locale +'/';
-                    files[files[file].locale +'/index'+ ext] = files[file];
+                    files[files[file].locale + sep + 'index'+ ext] = files[file];
                 }
 
                 // Remove old entry


### PR DESCRIPTION
"/index" leads to inconsistent key generation on metalsmith files.
E.g.: "en/index.md" when another file keys are "product\p1_en.md"